### PR TITLE
copy doc comment to module class in scala 3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -8,7 +8,7 @@ import mill.define.Command
 import mill.resolve.SelectMode
 import mill.resolve.Resolve
 object Settings {
-  val version = "0.11.0"
+  val version = "0.11.1"
   val pomOrg = "com.lihaoyi"
   val githubOrg = "com-lihaoyi"
   val githubRepo = "mill-moduledefs"

--- a/moduledefs/plugin/src-3/AutoOverridePluginDotty.scala
+++ b/moduledefs/plugin/src-3/AutoOverridePluginDotty.scala
@@ -49,7 +49,11 @@ class AutoOverridePluginDotty extends StandardPlugin {
         comment <- docCtx.docstring(sym)
       do {
         val text = NamedArg(valueName, Literal(Constant(comment.raw))).withSpan(span)
-        sym.addAnnotation(Annotation(ScalaDocAnnot, text, span))
+        val annot = Annotation(ScalaDocAnnot, text, span)
+        sym.addAnnotation(annot)
+        Option.when(sym.isTerm)(sym.moduleClass)
+          .filter(sym => sym.exists && !sym.hasAnnotation(ScalaDocAnnot))
+          .foreach(_.addAnnotation(annot))
       }
     }
 


### PR DESCRIPTION
It seems module classes do not inherit the `docCtx` of the module value, so is failing the `docannotations` test in mill.


In this PR I correct this by adding the Scaladoc annotation to the module class when we cook the comment for module values.

Tested in Mill repo with the module inspection task

e.g. https://github.com/com-lihaoyi/mill/blob/86606fb8534f1cc0938798fd51c7efbbc5846962/integration/feature/docannotations/resources/build.mill

```
$ mill -i inspect core

core(build.mill:67)
    The Core Module Docz!

Inherited Modules: Module, WithZincWorker, BspModule, RunModule, GenIdeaModule, CoursierModule, OfflineSupportModule, SemanticDbJavaModule, JavaModule

Default Task: core.run

Tasks: core.task
```

Also Scala 3 seems to include all transitive interfaces in the class file, making the inspect more verbose because they will be reported via reflection