### PR TITLE
Added support for Scala 2.13.16

### DIFF
--- a/PUBLISH_ONLY
+++ b/PUBLISH_ONLY
@@ -1,0 +1,1 @@
+moduledefs[2.13.16].plugin[2.13.16].publishArtifacts

--- a/build.sc
+++ b/build.sc
@@ -16,7 +16,7 @@ object Settings {
 }
 
 object Deps {
-  val scala2Versions = 0.to(15).map(v => "2.13." + v)
+  val scala2Versions = 0.to(16).map(v => "2.13." + v)
   val scala3Versions = Seq("3.5.0")
   val scalaAllVersions = Map(scala2Versions.last -> scala2Versions, scala3Versions.last -> scala3Versions)
   def scalaCompiler(scalaVersion: String) =


### PR DESCRIPTION
This allows us to transparently bump Mill 0.12 projects to Scala 2.13.16.