### PR TITLE
Simplify build and enable back-publish support for new Scala versions

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scala_version:
-        description: 'Single Scala version to add (SCALA_VERSION)'
+        description: 'Single Scala version to publish the scalac-plugin for (SCALA_VERSION)'
         type: string
         default: ''
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Publish selected version to Maven Central
         if: inputs.scala_version != ''
-        run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts "__.plugin[${{ inputs.scala_version }}].publishArtifacts"
+        run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts "plugin[${{ inputs.scala_version }}].publishArtifacts"
 
       - name: Create GitHub Release
         id: create_gh_release

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       scala_version:
-        description: 'Single Scala version to publish the scalac-plugin for (SCALA_VERSION)'
+        description: 'Single Scala version to just publish the scalac-plugin for SCALA_VERSION'
         type: string
         default: ''
 
@@ -39,7 +39,7 @@ jobs:
         if: inputs.scala_version == ''
         run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/
 
-      - name: Publish selected version to Maven Central
+      - name: Publish plugin for selected Scala version to Maven Central
         if: inputs.scala_version != ''
         run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts "plugin[${{ inputs.scala_version }}].publishArtifacts"
 

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - '**'
   workflow_dispatch:
+    inputs:
+      scala_version:
+        description: 'Single Scala version to add (SCALA_VERSION)'
+        type: string
+        default: ''
 
 jobs:
   publish-sonatype:
@@ -18,6 +23,7 @@ jobs:
       LANG: "en_US.UTF-8"
       LC_MESSAGES: "en_US.UTF-8"
       LC_ALL: "en_US.UTF-8"
+      SCALA_VERSION: ${{ inputs.scala_version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -25,8 +31,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-      - name: Publish to Maven Central
+
+      - name: Pre-publish testing
+        run: ./mill --no-server "__.publishM2Local" --m2RepoPath test-repo
+
+      - name: Publish all to Maven Central
+        if: inputs.scala_version == ''
         run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/
+
+      - name: Publish selected version to Maven Central
+        if: inputs.scala_version != ''
+        run: ./mill -i mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts "__.plugin[${{ inputs.scala_version }}].publishArtifacts"
 
       - name: Create GitHub Release
         id: create_gh_release

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -51,7 +51,9 @@ Publishing is automated via GitHub Actions.
 
 IMPORTANT: **You need to update the version manually, before creatign the git tag!**
 
-All git tags are automatically published. The tag should reflect the version number.
+Don't forget to update the changelog as well!
+
+Once you pushed the tag, it will be automatically published. The tag should reflect the version number.
 
 === Re-publish for a new Scala Release
 :example-version: 0.12.4

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -57,7 +57,7 @@ Don't forget to update the changelog as well!
 Once you pushed the tag, it will be automatically published. The tag should reflect the version number.
 
 === Re-publish for a new Scala Release
-:example-version: 0.12.4
+:example-version: 0.12.5
 :example-scala-version: 3.8.0
 
 The most frequently expected changes are releases for newer Scala version.
@@ -73,7 +73,7 @@ To do that:
 
 2. Find the "Run workflow" drop down (upper right corner)
 
-3. In the Branch-selector select the `Tags` tab and chosse the correct tag `{example-version}` (must be >= 0.12.4)
+3. In the Branch-selector select the `Tags` tab and chosse the correct tag `{example-version}` (must be >= 0.12.5)
 
 4. Press "Run workflow" to start the process
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -38,7 +38,7 @@ This project contains two modules:
 
 * `moduledefs` - Some shared code to be used in the Mill classpath. The `artifactName` is `mill-moduledefs`. This is cross-build to support Scala 2.13 and Scala 3
 
-* `plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`. This is crossbuild for all supported Scala compiler versions. If there is an older version missing, it is probably not supported. If a newer version is missing, please open an issue and/or pull request. If technically possible, we can also back-publish a recently published version for a new Scala release.
+* `plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`. This is crossbuild for all supported Scala compiler versions. If there is an older version missing, it is probably not supported. If a newer version is missing, please open an issue and/or pull request. If technically possible, we can also back-publish a recent version for a new Scala release.
 
 == Development and Releases
 

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -37,7 +37,7 @@ def scalacPluginIvyDeps = Agg(
 This project contains two modules:
 
 * `moduledefs` - Some shared code to be used in the Mill classpath. The `artifactName` is `mill-moduledefs`.
-* `moduledefs/plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`.
+* `plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`.
 
 == Development and Releases
 
@@ -47,50 +47,34 @@ It should be especially kept stable within the same Mill major version.
 
 === Publishing
 
-Publishing is automated via GitHub Actions and implemented in the `publishToSonatype` command.
+Publishing is automated via GitHub Actions.
 
-[source,scala]
-----
-def publishToSonatype(
-    sonatypeCreds: String,
-    gpgArgs: String = PublishModule.defaultGpgArgs.mkString(","),
-    dryRun: Boolean = false,
-    artifactsFile: Option[String] = None
-): Command[Unit]
-----
-
-**You need to update the version manually, before creatign the git tag!**
+IMPORTANT: **You need to update the version manually, before creatign the git tag!**
 
 All git tags are automatically published. The tag should reflect the version number.
 
-
 === Re-publish for a new Scala Release
-:example-version: 0.10.9
-:example-scala-version: 2.13.10
+:example-version: 0.12.4
+:example-scala-version: 3.8.0
 
 The most frequently expected changes are releases for newer Scala version.
 This is especially needed, as compiler plugins are tied to the exact Scala compiler version.
 
 Hence, this build aims to be flexible enough, to release an already tagged version for newer Scalac releases after the fact.
 
-As an example, to release an already published version `{example-version}` for a new Scala version `{example-scala-version}`, follow these steps:
+As an example, we want to release an already published version `{example-version}` for a new Scala version `{example-scala-version}`:
 
-. Create a branch `release-{example-version}` from the git tag `{example-version}`.
+To do that:
 
-. Add the new Scala version to the build setup. Make sure you don't change the actual code, so it stays compatible to the original tag.
+1. Select the `publish-artifacts.yml` workflow
 
-. Add a file `PUBLISH_ONLY` containing a selector for the artifacts to publish. If you need more than one selector, place each on a new line.
-+
-.Example file `PUBLISH_ONLY`
-----
-moduledefs.plugin[2.13.10].publishArtifacts
-----
+2. Find the "Run workflow" drop down (upper right corner)
 
-. Commit your changes.
+3. In the Branch-selector select the `Tags` tab and chosse the correct tag `{example-version}` (must be >= 0.12.4)
 
-. Tag your commit with `{example-version}-for-{example-scala-version}`. This will trigger the `publish-sonatype` workflow in GHA.
+4. Press "Run workflow" to start the process
 
-. If appropriate, update the Readme/Changelog in the `main` branch.
+IMPORTANT: Remember to also open a pull request against the `main` branch, to make the support for the new Scala version permanent.
 
 
 == License

--- a/Readme.adoc
+++ b/Readme.adoc
@@ -36,8 +36,9 @@ def scalacPluginIvyDeps = Agg(
 
 This project contains two modules:
 
-* `moduledefs` - Some shared code to be used in the Mill classpath. The `artifactName` is `mill-moduledefs`.
-* `plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`.
+* `moduledefs` - Some shared code to be used in the Mill classpath. The `artifactName` is `mill-moduledefs`. This is cross-build to support Scala 2.13 and Scala 3
+
+* `plugin` - A Scalac compiler plugin to be used when compiling Mill projects. The `artifactName` is `scalac-mill-moduledefs-plugin`. This is crossbuild for all supported Scala compiler versions. If there is an older version missing, it is probably not supported. If a newer version is missing, please open an issue and/or pull request. If technically possible, we can also back-publish a recently published version for a new Scala release.
 
 == Development and Releases
 

--- a/build.mill
+++ b/build.mill
@@ -13,28 +13,35 @@ object Settings {
 }
 
 object Deps {
-  val scalaVersionEnv = sys.env.get("SCALA_VERSION")
-    .map(_.trim)
-    .filter(_.nonEmpty)
-    .tapEach(v => println(s"Adding environmental defined Scala version to version matrix. SCALA_VERSION=${v}"))
-    .toSeq
-
-  val scala2Versions = 0.to(18).map(v => "2.13." + v) ++ scalaVersionEnv.filter(_.startsWith("2.13"))
-  val scala3Versions = Seq("3.7.0", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.8.0-RC1", "3.8.0-RC2", "3.8.0-RC3") ++
-    scalaVersionEnv.filter(_.startsWith("3"))
 
   // 2.13.18 is latest forward-compatible 2.13 version
   val libScala2Version = "2.13.18"
   // 3.7.4 is forward-compatible to 3.7, which is our lowest supported 3 version
   val libScala3Version = "3.7.4"
 
+  val scalaVersionEnv = sys.env.get("SCALA_VERSION")
+    .map(_.trim)
+    .filter(_.nonEmpty)
+    .tapEach(v => println(s"Adding environmental defined Scala version to version matrix. SCALA_VERSION=${v}"))
+    .toSeq
+
+  val scala2Versions = (
+    0.to(17).map(v => "2.13." + v) ++
+      Seq(libScala2Version) ++
+      scalaVersionEnv.filter(_.startsWith("2.13"))
+    ).distinct
+
+  val scala3Versions = (
+    Seq("3.7.0", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.8.0-RC1", "3.8.0-RC2", "3.8.0-RC3") ++
+      Seq(libScala3Version) ++
+      scalaVersionEnv.filter(_.startsWith("3"))
+    ).distinct
+
   val libScalaVersions = Seq(libScala2Version, libScala3Version)
   val pluginScalaVersions: Map[String, String] =    (
     scala2Versions.map(_ -> libScala2Version) ++
       scala3Versions.map(_ -> libScala3Version)
     ).toMap
-
-  pprint.log(pluginScalaVersions)
 
   def scalaCompiler(scalaVersion: String) =
     if (scalaVersion.startsWith("3.")) ivy"org.scala-lang::scala3-compiler:${scalaVersion}"

--- a/build.mill
+++ b/build.mill
@@ -19,10 +19,40 @@ object Deps {
     scala2Versions.last -> scala2Versions,
     "3.7.4" -> scala3Versions,
   )
+  val scalaVersionEnv = sys.env.get("SCALA_VERSION")
+    .map(_.trim)
+    .filter(_.nonEmpty)
+    .tapEach(v => println(s"Adding environmental defined Scala version to version matrix. SCALA_VERSION=${v}"))
+    .toSeq
+
+  val allVersions = scala2Versions ++ scala3Versions ++ scalaVersionEnv
+  val scalaAllVersions = allVersions.distinct
+    // group by major.minor
+    .groupBy(_
+      .split("[.]", 3)
+      .take(2)
+      .mkString(".")
+    )
+    .view
+    // sort, oldest first
+    .mapValues(vs => vs
+      .map(v => mill.util.Version.parse(v))
+      .sorted(mill.util.Version.MavenOrdering)
+      .map(_.toString())
+    )
+    .toMap
+    // put the newest version per group
+    .map(v => (v._2.last, v._2))
+
   def scalaCompiler(scalaVersion: String) =
     if (scalaVersion.startsWith("3.")) ivy"org.scala-lang::scala3-compiler:${scalaVersion}"
     else ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"
+}
+
+def dump() = Task.Command {
+  pprint.log(Deps.allVersions)
+  pprint.log(Deps.scalaAllVersions)
 }
 
 trait ModuledefsBase extends ScalaModule with PublishModule {

--- a/build.mill
+++ b/build.mill
@@ -1,9 +1,12 @@
 //| mill-version: 1.1.0-RC2
 //| mill-jvm-version: 11
+package build
+
 import mill.scalalib._
 import mill.scalalib.publish._
 import mill.api.*
 import mill.*
+
 object Settings {
   val version = "0.12.4"
   val pomOrg = "com.lihaoyi"
@@ -102,60 +105,3 @@ trait PluginCross extends CrossScalaModule with ModuledefsBase {
     super.resources() ++ versionedResources()
   }
 }
-
-//def publishToSonatype(
-//    sonatypeCreds: String,
-//    gpgArgs: String = PublishModule.defaultGpgArgs.mkString(","),
-//    dryRun: Boolean = false,
-//    artifactsFile: Option[String] = None,
-//    eval: Evaluator
-//): Command[Unit] = {
-//
-//  val pubTasks: Seq[String] = artifactsFile.map(f => os.Path(f, os.pwd)).filter(os.exists) match {
-//    case None => Seq("__.publishArtifacts")
-//    case Some(f) =>
-//      val tasks = os.read.lines(f)
-//        .map(_.trim())
-//        .filter(l => l.nonEmpty && !l.startsWith("#"))
-//      if (tasks.isEmpty) sys.error(s"No artifacts tasks selected. File ${f} cannot be empty.")
-//      tasks
-//  }
-//
-//  val Result.Success(tasks) = eval.resolveTasks(
-//    pubTasks,
-//    SelectMode.Separated
-//  )
-//
-//  Task.Command {
-//    val pubArtifacts: Seq[(Seq[(os.Path, String)], Artifact)] = Task.sequence(tasks)().map {
-//      case PublishModule.PublishData(a, s) => (s.map { case (p, f) => (p.path, f) }, a)
-//    }
-//
-//    Task.log.debug(s"Publishing artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}")
-//
-//    if (dryRun) {
-//      Task.log.info(
-//        s"Skipping publish for artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}"
-//      )
-//    } else {
-//      new SonatypePublisher(
-//        uri = "https://oss.sonatype.org/service/local",
-//        snapshotUri = "https://oss.sonatype.org/content/repositories/snapshots",
-//        sonatypeCreds,
-//        signed = true,
-//        gpgArgs.split(',').toIndexedSeq,
-//        readTimeout = 6000000,
-//        connectTimeout = 600000,
-//        Task.log,
-//        BuildCtx.workspaceRoot,
-//        Task.env,
-//        awaitTimeout = 600000,
-//        stagingRelease = true
-//      ).publishAll(
-//        release = true,
-//        pubArtifacts: _*
-//      )
-//    }
-//  }
-//
-//}

--- a/build.mill
+++ b/build.mill
@@ -13,46 +13,33 @@ object Settings {
 }
 
 object Deps {
-  val scala2Versions = 0.to(15).map(v => "2.13." + v)
-  val scala3Versions = Seq("3.7.0", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.8.0-RC1", "3.8.0-RC2", "3.8.0-RC3")
-  val scalaAllVersions = Map(
-    scala2Versions.last -> scala2Versions,
-    "3.7.4" -> scala3Versions,
-  )
   val scalaVersionEnv = sys.env.get("SCALA_VERSION")
     .map(_.trim)
     .filter(_.nonEmpty)
     .tapEach(v => println(s"Adding environmental defined Scala version to version matrix. SCALA_VERSION=${v}"))
     .toSeq
 
-  val allVersions = scala2Versions ++ scala3Versions ++ scalaVersionEnv
-  val scalaAllVersions = allVersions.distinct
-    // group by major.minor
-    .groupBy(_
-      .split("[.]", 3)
-      .take(2)
-      .mkString(".")
-    )
-    .view
-    // sort, oldest first
-    .mapValues(vs => vs
-      .map(v => mill.util.Version.parse(v))
-      .sorted(mill.util.Version.MavenOrdering)
-      .map(_.toString())
-    )
-    .toMap
-    // put the newest version per group
-    .map(v => (v._2.last, v._2))
+  val scala2Versions = 0.to(18).map(v => "2.13." + v) ++ scalaVersionEnv.filter(_.startsWith("2.13"))
+  val scala3Versions = Seq("3.7.0", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.8.0-RC1", "3.8.0-RC2", "3.8.0-RC3") ++
+    scalaVersionEnv.filter(_.startsWith("3"))
+
+  // 2.13.18 is latest forward-compatible 2.13 version
+  val libScala2Version = "2.13.18"
+  // 3.7.4 is forward-compatible to 3.7, which is our lowest supported 3 version
+  val libScala3Version = "3.7.4"
+
+  val libScalaVersions = Seq(libScala2Version, libScala3Version)
+  val pluginScalaVersions: Map[String, String] =    (
+    scala2Versions.map(_ -> libScala2Version) ++
+      scala3Versions.map(_ -> libScala3Version)
+    ).toMap
+
+  pprint.log(pluginScalaVersions)
 
   def scalaCompiler(scalaVersion: String) =
     if (scalaVersion.startsWith("3.")) ivy"org.scala-lang::scala3-compiler:${scalaVersion}"
     else ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.3.0"
-}
-
-def dump() = Task.Command {
-  pprint.log(Deps.allVersions)
-  pprint.log(Deps.scalaAllVersions)
 }
 
 trait ModuledefsBase extends ScalaModule with PublishModule {
@@ -78,91 +65,90 @@ trait ModuledefsBase extends ScalaModule with PublishModule {
   }
 }
 
-object moduledefs extends Cross[ModuleDefsCross](Deps.scalaAllVersions.keys.toSeq)
-trait ModuleDefsCross extends CrossScalaModule  with ModuledefsBase { outer =>
+object moduledefs extends Cross[ModuleDefsCross](Deps.libScalaVersions)
+trait ModuleDefsCross extends CrossScalaModule  with ModuledefsBase {
+  outer =>
   override def artifactName = "mill-" + super.artifactName()
+
   override def mvnDeps = {
     val sv = crossScalaVersion
     Seq(Deps.sourcecode) ++
       (if (sv.startsWith("2.")) Seq(Deps.scalaCompiler(sv)) else Seq.empty)
   }
-
-  object plugin extends Cross[PluginCross](Deps.scalaAllVersions(crossScalaVersion))
-  trait PluginCross extends CrossScalaModule
-      with ModuledefsBase {
-    override def artifactName = "scalac-mill-moduledefs-plugin"
-                                          // ^^ TODO: cant use `"scalac-mill-" + super.artifactName()` here
-                                          //    because it includes the crossScalaVersion of `moduledefs`
-                                          //    could be addressed with Cross2 from mill 0.11.x
-    override def moduleDeps = Seq(moduledefs(outer.crossScalaVersion))
-    override def crossFullScalaVersion = true
-    override def mvnDeps = Seq(
-      Deps.scalaCompiler(crossScalaVersion),
-      Deps.sourcecode
-    )
-
-    def versionedResources = Task.Sources(
-      scalaVersionDirectoryNames.map(dir => moduleDir / s"resources-$dir")*
-    )
-    override def resources = Task {
-      super.resources() ++ versionedResources()
-    }
-  }
 }
 
-def publishToSonatype(
-    sonatypeCreds: String,
-    gpgArgs: String = PublishModule.defaultGpgArgs.mkString(","),
-    dryRun: Boolean = false,
-    artifactsFile: Option[String] = None,
-    eval: Evaluator
-): Command[Unit] = {
-
-  val pubTasks: Seq[String] = artifactsFile.map(f => os.Path(f, os.pwd)).filter(os.exists) match {
-    case None => Seq("__.publishArtifacts")
-    case Some(f) =>
-      val tasks = os.read.lines(f)
-        .map(_.trim())
-        .filter(l => l.nonEmpty && !l.startsWith("#"))
-      if (tasks.isEmpty) sys.error(s"No artifacts tasks selected. File ${f} cannot be empty.")
-      tasks
-  }
-
-  val Result.Success(tasks) = eval.resolveTasks(
-    pubTasks,
-    SelectMode.Separated
+object plugin extends Cross[PluginCross](Deps.pluginScalaVersions.keys.toSeq)
+trait PluginCross extends CrossScalaModule with ModuledefsBase {
+  override def moduleDir = moduledefs.moduleDir / "plugin"
+  override def artifactName = "scalac-mill-moduledefs-plugin"
+  override def moduleDeps = Seq(moduledefs(Deps.pluginScalaVersions(crossScalaVersion)))
+  override def crossFullScalaVersion = true
+  override def mvnDeps = Seq(
+    Deps.scalaCompiler(crossScalaVersion),
+    Deps.sourcecode
   )
 
-  Task.Command {
-    val pubArtifacts: Seq[(Seq[(os.Path, String)], Artifact)] = Task.sequence(tasks)().map {
-      case PublishModule.PublishData(a, s) => (s.map { case (p, f) => (p.path, f) }, a)
-    }
-
-    Task.log.debug(s"Publishing artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}")
-
-    if (dryRun) {
-      Task.log.info(
-        s"Skipping publish for artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}"
-      )
-    } else {
-      new SonatypePublisher(
-        uri = "https://oss.sonatype.org/service/local",
-        snapshotUri = "https://oss.sonatype.org/content/repositories/snapshots",
-        sonatypeCreds,
-        signed = true,
-        gpgArgs.split(',').toIndexedSeq,
-        readTimeout = 6000000,
-        connectTimeout = 600000,
-        Task.log,
-        BuildCtx.workspaceRoot,
-        Task.env,
-        awaitTimeout = 600000,
-        stagingRelease = true
-      ).publishAll(
-        release = true,
-        pubArtifacts: _*
-      )
-    }
+  def versionedResources = Task.Sources(
+    scalaVersionDirectoryNames.map(dir => moduleDir / s"resources-$dir")*
+  )
+  override def resources = Task {
+    super.resources() ++ versionedResources()
   }
-
 }
+
+//def publishToSonatype(
+//    sonatypeCreds: String,
+//    gpgArgs: String = PublishModule.defaultGpgArgs.mkString(","),
+//    dryRun: Boolean = false,
+//    artifactsFile: Option[String] = None,
+//    eval: Evaluator
+//): Command[Unit] = {
+//
+//  val pubTasks: Seq[String] = artifactsFile.map(f => os.Path(f, os.pwd)).filter(os.exists) match {
+//    case None => Seq("__.publishArtifacts")
+//    case Some(f) =>
+//      val tasks = os.read.lines(f)
+//        .map(_.trim())
+//        .filter(l => l.nonEmpty && !l.startsWith("#"))
+//      if (tasks.isEmpty) sys.error(s"No artifacts tasks selected. File ${f} cannot be empty.")
+//      tasks
+//  }
+//
+//  val Result.Success(tasks) = eval.resolveTasks(
+//    pubTasks,
+//    SelectMode.Separated
+//  )
+//
+//  Task.Command {
+//    val pubArtifacts: Seq[(Seq[(os.Path, String)], Artifact)] = Task.sequence(tasks)().map {
+//      case PublishModule.PublishData(a, s) => (s.map { case (p, f) => (p.path, f) }, a)
+//    }
+//
+//    Task.log.debug(s"Publishing artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}")
+//
+//    if (dryRun) {
+//      Task.log.info(
+//        s"Skipping publish for artifacts: ${pubArtifacts.map(_._2).mkString("\n  ", "\n  ", "")}"
+//      )
+//    } else {
+//      new SonatypePublisher(
+//        uri = "https://oss.sonatype.org/service/local",
+//        snapshotUri = "https://oss.sonatype.org/content/repositories/snapshots",
+//        sonatypeCreds,
+//        signed = true,
+//        gpgArgs.split(',').toIndexedSeq,
+//        readTimeout = 6000000,
+//        connectTimeout = 600000,
+//        Task.log,
+//        BuildCtx.workspaceRoot,
+//        Task.env,
+//        awaitTimeout = 600000,
+//        stagingRelease = true
+//      ).publishAll(
+//        release = true,
+//        pubArtifacts: _*
+//      )
+//    }
+//  }
+//
+//}


### PR DESCRIPTION
* Refactored the build. The `plugin` cross-module is no longer a sub-module of the `moduledefs` cross-module. This removes the need to specify the correct Scala version of the `moduledefs` module. For example, to build the plugin for Scala `3.8.0-RC3`, it is now enough to run `mill plugin[3.8.0-RC3].compile`, whereas before, we needed to run `mill moduledefs[3.7.4].plugin[3.8.0-RC3].compile`. The artifact IDs weren't changed.

* When a `SCALA_VERSION` env variable is defined, that Scala version is added to the target versions to which the plugin will be build. Example: To build the plugin for Scala `3.8.0-RC4` without changing the `build.mill` file, you can now run `SCALA_VERSION=3.8.0-RC4 mill plugin[3.8.0-RC4].compile`.

* The Github publish workflow dispatch now supports a `SCALA_VERSION` parameter. When set, the workflow will only publish the plugin for that specific Scala version. This allows us to back-publish for a specific Scala version without any changes to the repository. (The build workflow will still build all artifacts.) It is still preferred, to open a PR to add a new Scala version permanently. The new back-publishing allows us to support Scala updates in projects that want to stay on an older Mill version.

* Removed the `publishToSonatype` command from the `build.mill` file, which was no longer in use and looked outdated, as it was not using the newer `SonatypeCentralPublishModule`.

* Updated the developer instructions and deleted mentions of the previous back-publish workflow.

Pull request: https://github.com/com-lihaoyi/mill-moduledefs/pull/28